### PR TITLE
Fix for missing close paren in palante_monitoring.module

### DIFF
--- a/palante_monitoring.module
+++ b/palante_monitoring.module
@@ -135,7 +135,7 @@ function palante_monitoring_backups(&$requirements) {
 
   // Filter for only those destinations which match the strings "daily" or "weekly"
   $filteredDestinations = array_filter($destinations, function($obj){
-    if(isset($obj->location) {
+    if(isset($obj->location)) {
       return (strpos($obj->location, "daily")) || (strpos($obj->location, "weekly"));
     }
   });


### PR DESCRIPTION
After enabling the most recent version of palante_monitoring on the new AAJC site I'm setting up, I started getting this error:

`PHP Parse error:  syntax error, unexpected '{' in /var/www/sitename.org/public_html/sites/all/modules/custom/palante_monitoring/palante_monitoring.module on line 138`

A close paren was missing on that line; I've added it and the module now works properly!
